### PR TITLE
Make the API Gateway reactive

### DIFF
--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("org.springframework.boot") version "3.3.2"
+    id("org.springframework.boot") version "3.3.4"
     id("io.spring.dependency-management") version "1.1.6"
 }
 

--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -29,12 +29,11 @@ dependencies {
     compileOnly(Libraries.lombok)
     annotationProcessor(Libraries.lombok)
 
-    implementation(Libraries.springboot)
     implementation(Libraries.springbootGraphQl)
     implementation(Libraries.springbootValidation)
     implementation(Libraries.vavr)
     implementation(Libraries.swagger)
-    implementation(Libraries.springbootWeb)
+    implementation(Libraries.springbootWebFlux)
     implementation(Libraries.httpcomponentsClient)
 
 

--- a/api-gateway/src/main/java/com/globant/http/CartController.java
+++ b/api-gateway/src/main/java/com/globant/http/CartController.java
@@ -12,6 +12,7 @@ import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
+import reactor.core.publisher.Mono;
 
 @Controller
 @RequiredArgsConstructor
@@ -20,21 +21,21 @@ public class CartController {
     private final CartResolver cartResolver;
 
     @QueryMapping
-    public CartTotal getCart(
+    public Mono<CartTotal> getCart(
             @Argument @Positive @Digits(integer = 20, fraction = 0) Integer documentNumber
     ) {
         return cartResolver.getCart(documentNumber);
     }
 
     @MutationMapping
-    public CartTotal addToCart(
+    public Mono<CartTotal> addToCart(
             @Argument @Positive @Digits(integer = 20, fraction = 0) Integer documentNumber,
             @Argument @Valid AddCartComboInput cartCombo) {
         return cartResolver.addToCart(documentNumber, cartCombo);
     }
 
     @MutationMapping
-    public CartTotal removeFromCart(
+    public Mono<CartTotal> removeFromCart(
             @Argument @Positive @Digits(integer = 20, fraction = 0) Integer documentNumber,
             @Argument @UUID String productId
     ) {
@@ -42,7 +43,7 @@ public class CartController {
     }
 
     @MutationMapping
-    public CartTotal clearCart(@Argument @Positive @Digits(integer = 20, fraction = 0) Integer documentNumber) {
+    public Mono<CartTotal> clearCart(@Argument @Positive @Digits(integer = 20, fraction = 0) Integer documentNumber) {
         return cartResolver.clearCart(documentNumber);
     }
 }

--- a/api-gateway/src/main/java/com/globant/http/PaymentController.java
+++ b/api-gateway/src/main/java/com/globant/http/PaymentController.java
@@ -12,6 +12,8 @@ import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -28,17 +30,17 @@ public class PaymentController {
     }
 
     @QueryMapping
-    public List<CreatedOrder> allOrders() {
+    public Flux<CreatedOrder> allOrders() {
         return paymentResolver.getAllOrders();
     }
 
     @MutationMapping
-    public CreatedOrder createOrder(@Argument(name = "input") @Valid CheckoutOrder checkoutOrder) {
+    public Mono<CreatedOrder> createOrder(@Argument(name = "input") @Valid CheckoutOrder checkoutOrder) {
         return paymentResolver.checkout(checkoutOrder);
     }
 
     @MutationMapping
-    public CreatedOrder deliverOrder(
+    public Mono<CreatedOrder> deliverOrder(
             @Argument @UUID String orderId,
             @Argument @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) String deliveryTime
     ) {
@@ -47,4 +49,5 @@ public class PaymentController {
                 LocalDateTime.from(DateTimeFormatter.ISO_DATE_TIME.parse(deliveryTime))
         );
     }
+
 }

--- a/api-gateway/src/main/java/com/globant/http/ProductController.java
+++ b/api-gateway/src/main/java/com/globant/http/ProductController.java
@@ -11,6 +11,8 @@ import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.UUID;
@@ -25,37 +27,36 @@ public class ProductController {
     }
 
     @QueryMapping
-    public List<Combo> allCombos() {
+    public Flux<Combo> allCombos() {
         return productResolver.getAll();
     }
 
     @QueryMapping
-    public Combo comboByUuid(@Argument @NotEmpty @org.hibernate.validator.constraints.UUID String uuid) {
+    public Mono<Combo> comboByUuid(@Argument @NotEmpty @org.hibernate.validator.constraints.UUID String uuid) {
         return productResolver.searchByUuid(UUID.fromString(uuid));
     }
 
     @QueryMapping
-    public List<Combo> combosByName(@Argument @NotEmpty String name) {
+    public Flux<Combo> combosByName(@Argument @NotEmpty String name) {
         return productResolver.searchByName(name);
     }
 
     @MutationMapping
-    public Combo createCombo(@Argument(name = "input") @Valid CreateCombo combo) {
+    public Mono<Combo> createCombo(@Argument(name = "input") @Valid CreateCombo combo) {
         return productResolver.addCombo(combo);
     }
 
     @MutationMapping
-    public void updateCombo(
+    public Mono<Void> updateCombo(
             @Argument @NotEmpty
             @org.hibernate.validator.constraints.UUID String uuid,
             @Argument(name = "input") @Valid UpdateCombo combo
     ) {
-        productResolver.updateCombo(UUID.fromString(uuid), combo);
+        return productResolver.updateCombo(UUID.fromString(uuid), combo);
     }
 
     @MutationMapping
-    public void deleteCombo(@Argument @org.hibernate.validator.constraints.UUID String uuid) {
-        productResolver.deleteCombo(UUID.fromString(uuid));
+    public Mono<Void> deleteCombo(@Argument @org.hibernate.validator.constraints.UUID String uuid) {
+        return productResolver.deleteCombo(UUID.fromString(uuid));
     }
-
 }

--- a/api-gateway/src/main/java/com/globant/http/UserController.java
+++ b/api-gateway/src/main/java/com/globant/http/UserController.java
@@ -10,16 +10,13 @@ import domain.user.DocumentIdentity;
 import com.globant.domain.user.UpdateUserInput;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-import java.util.List;
-import java.util.Optional;
-
-@Slf4j
 @Controller
 public class UserController {
 
@@ -30,17 +27,17 @@ public class UserController {
     }
 
     @QueryMapping
-    public List<User> allUsers() {
+    public Flux<User> allUsers() {
         return userResolver.getAllUsers();
     }
 
     @QueryMapping
-    public User userByDocumentNumber(@Argument @NotEmpty String documentNumber) {
+    public Mono<User> userByDocumentNumber(@Argument @NotEmpty String documentNumber) {
         return userResolver.getUserByDocumentNumber(documentNumber);
     }
 
     @MutationMapping
-    public User createUser(@Argument @Valid CreateUserInput input){
+    public Mono<User> createUser(@Argument @Valid CreateUserInput input){
         User newUser = new User(
                 new DocumentIdentity(input.getDocumentIdentity().getDocumentType(), input.getDocumentIdentity().getDocumentNumber()),
                 input.getFirstName(),
@@ -54,36 +51,21 @@ public class UserController {
     }
 
     @MutationMapping
-    public User updateUser(@Argument @NotEmpty String documentNumber,
-                           @Argument(name = "input") @Valid UpdateUserInput updateUserInput){
-        User existingUser = userResolver.getUserByDocumentNumber(documentNumber);
+    public Mono<User> updateUser(
+            @Argument @NotEmpty String documentNumber,
+            @Argument(name = "input") @Valid UpdateUserInput updateUserInput
+    ) {
 
-        User updatedUser = new User(
-                existingUser.documentIdentity(),
-                Optional.ofNullable(updateUserInput.firstName()).orElse(existingUser.firstName()),
-                Optional.ofNullable(updateUserInput.lastName()).orElse(existingUser.lastName()),
-                Optional.ofNullable(updateUserInput.email()).orElse(existingUser.email()),
-                Optional.ofNullable(updateUserInput.phoneNumber()).orElse(existingUser.phoneNumber()),
-                Optional.ofNullable(updateUserInput.address()).orElse(existingUser.address())
-//                Optional.ofNullable(updateUserInput.firstName()).orElse(existingUser.firstName()),
-//                updateUserInput.lastName() != null ? updateUserInput.lastName() : existingUser.lastName(),
-//                updateUserInput.email() != null ? updateUserInput.email() : existingUser.email(),
-//                updateUserInput.phoneNumber() != null ? updateUserInput.phoneNumber() : existingUser.phoneNumber(),
-//                updateUserInput.address() != null ? updateUserInput.address() : existingUser.address()
-        );
-
-        log.info(updatedUser.toString());
-
-        return userResolver.updateUser(documentNumber, updatedUser);
+        return userResolver.updateUser(documentNumber, updateUserInput);
     }
 
     @MutationMapping
-    public boolean deleteUser(@Argument @NotEmpty String documentNumber){
+    public Mono<Boolean> deleteUser(@Argument @NotEmpty String documentNumber){
         return userResolver.deleteUser(documentNumber);
     }
 
     @QueryMapping
-    public List<User> userByFirstName(@Argument("firstName") @NotEmpty String firstName){
+    public Flux<User> userByFirstName(@Argument("firstName") @NotEmpty String firstName){
         return userResolver.getUserByFirstName(firstName);
     }
 

--- a/api-gateway/src/main/java/com/globant/resolvers/CartResolver.java
+++ b/api-gateway/src/main/java/com/globant/resolvers/CartResolver.java
@@ -2,12 +2,13 @@ package com.globant.resolvers;
 
 import com.globant.domain.cart.AddCartComboInput;
 import domain.cart.CartTotal;
+import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
 public interface CartResolver {
-    CartTotal getCart(Integer userId);
-    CartTotal addToCart(Integer userId, AddCartComboInput cartCombo);
-    CartTotal removeFromCart(Integer userId, UUID productId);
-    CartTotal clearCart(Integer userId);
+    Mono<CartTotal> getCart(Integer userId);
+    Mono<CartTotal> addToCart(Integer userId, AddCartComboInput cartCombo);
+    Mono<CartTotal> removeFromCart(Integer userId, UUID productId);
+    Mono<CartTotal> clearCart(Integer userId);
 }

--- a/api-gateway/src/main/java/com/globant/resolvers/PaymentResolver.java
+++ b/api-gateway/src/main/java/com/globant/resolvers/PaymentResolver.java
@@ -3,13 +3,15 @@ package com.globant.resolvers;
 import com.globant.domain.order.CheckoutOrder;
 import domain.payment.CreateOrder;
 import domain.payment.CreatedOrder;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 public interface PaymentResolver {
-    List<CreatedOrder> getAllOrders();
-    CreatedOrder checkout(CheckoutOrder checkoutOrder);
-    CreatedOrder deliverOrder(UUID orderId, LocalDateTime deliveryTime);
+    Flux<CreatedOrder> getAllOrders();
+    Mono<CreatedOrder> checkout(CheckoutOrder checkoutOrder);
+    Mono<CreatedOrder> deliverOrder(UUID orderId, LocalDateTime deliveryTime);
 }

--- a/api-gateway/src/main/java/com/globant/resolvers/ProductResolver.java
+++ b/api-gateway/src/main/java/com/globant/resolvers/ProductResolver.java
@@ -4,6 +4,8 @@ import domain.combo.Combo;
 import domain.combo.CreateCombo;
 import domain.combo.UpdateCombo;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.UUID;
@@ -11,12 +13,12 @@ import java.util.UUID;
 public interface ProductResolver {
 
     // Queries
-    List<Combo> getAll();
-    Combo searchByUuid(UUID uuid);
-    List<Combo> searchByName(String name);
+    Flux<Combo> getAll();
+    Mono<Combo> searchByUuid(UUID uuid);
+    Flux<Combo> searchByName(String name);
 
     // Mutations
-    Combo addCombo(CreateCombo createCombo);
-    Void updateCombo(UUID uuid, UpdateCombo updateCombo);
-    Void deleteCombo(UUID uuid);
+    Mono<Combo> addCombo(CreateCombo createCombo);
+    Mono<Void> updateCombo(UUID uuid, UpdateCombo updateCombo);
+    Mono<Void> deleteCombo(UUID uuid);
 }

--- a/api-gateway/src/main/java/com/globant/resolvers/UserResolver.java
+++ b/api-gateway/src/main/java/com/globant/resolvers/UserResolver.java
@@ -1,15 +1,18 @@
 package com.globant.resolvers;
 
+import com.globant.domain.user.UpdateUserInput;
 import com.globant.domain.user.User;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 
 public interface UserResolver {
 
-    User createUser(User newUser);
-    List<User> getAllUsers();
-    User updateUser(String documentNumber, User updateUser);
-    boolean deleteUser(String documentNumber);
-    User getUserByDocumentNumber(String documentNumber);
-    List<User> getUserByFirstName(String firstName);
+    Mono<User> createUser(User newUser);
+    Flux<User> getAllUsers();
+    Mono<User> updateUser(String documentNumber, UpdateUserInput updateUserInput);
+    Mono<Boolean> deleteUser(String documentNumber);
+    Mono<User> getUserByDocumentNumber(String documentNumber);
+    Flux<User> getUserByFirstName(String firstName);
 }

--- a/api-gateway/src/main/java/com/globant/resolvers/implementations/ProductResolverImpl.java
+++ b/api-gateway/src/main/java/com/globant/resolvers/implementations/ProductResolverImpl.java
@@ -6,74 +6,75 @@ import domain.combo.CreateCombo;
 import domain.combo.UpdateCombo;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-import java.util.List;
 import java.util.UUID;
 
 @Component
 public class ProductResolverImpl implements ProductResolver {
 
-    private final RestClient restClient;
+    private final WebClient webClient;
 
-    public ProductResolverImpl(RestClient.Builder builder) {
-        this.restClient = builder
+    public ProductResolverImpl(WebClient.Builder builder) {
+        this.webClient = builder
                 .baseUrl("http://localhost:8082")
                 .build();
     }
 
 
     @Override
-    public List<Combo> getAll() {
-        return restClient.get()
+    public Flux<Combo> getAll() {
+        return webClient.get()
                 .uri("/products")
                 .retrieve()
-                .body(new ParameterizedTypeReference<List<Combo>>() {});
+                .bodyToFlux(new ParameterizedTypeReference<Combo>() {});
     }
 
     @Override
-    public Combo searchByUuid(UUID uuid) {
-        return restClient.get()
+    public Mono<Combo> searchByUuid(UUID uuid) {
+        return webClient.get()
                 .uri("/products/{uuid}", uuid)
                 .retrieve()
-                .body(Combo.class);
+                .bodyToMono(Combo.class);
     }
 
     @Override
-    public List<Combo> searchByName(String name) {
-        return restClient.get()
+    public Flux<Combo> searchByName(String name) {
+        return webClient.get()
                 .uri( uriBuilder -> uriBuilder
                         .path("/products/search")
                         .queryParam("q", name)
                         .build())
                 .retrieve()
-                .body(new ParameterizedTypeReference<List<Combo>>() {});
+                .bodyToFlux(Combo.class);
     }
 
     @Override
-    public Combo addCombo(CreateCombo createCombo) {
-        return restClient.post()
+    public Mono<Combo> addCombo(CreateCombo createCombo) {
+        return webClient.post()
                 .uri("/products")
                 .body(createCombo, new ParameterizedTypeReference<CreateCombo>() {})
                 .retrieve()
-                .body(Combo.class);
+                .bodyToMono(Combo.class);
     }
 
     @Override
-    public Void updateCombo(UUID uuid, UpdateCombo updateCombo) {
-        return restClient.put()
+    public Mono<Void> updateCombo(UUID uuid, UpdateCombo updateCombo) {
+        return webClient.put()
                 .uri("/products/{uuid}", uuid)
                 .body(updateCombo, new ParameterizedTypeReference<UpdateCombo>() {})
                 .retrieve()
-                .body(Void.class);
+                .bodyToMono(Void.class);
 
     }
 
     @Override
-    public Void deleteCombo(UUID uuid) {
-        return restClient.delete()
+    public Mono<Void> deleteCombo(UUID uuid) {
+        return webClient.delete()
                 .uri("/products/{uuid}", uuid)
                 .retrieve()
-                .body(Void.class);
+                .bodyToMono(Void.class);
     }
 }

--- a/api-gateway/src/main/java/com/globant/resolvers/implementations/UserResolverImpl.java
+++ b/api-gateway/src/main/java/com/globant/resolvers/implementations/UserResolverImpl.java
@@ -1,67 +1,89 @@
 package com.globant.resolvers.implementations;
 
+import com.globant.domain.user.UpdateUserInput;
 import com.globant.domain.user.User;
 import com.globant.resolvers.UserResolver;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.Optional;
 
 @Component
 public class UserResolverImpl implements UserResolver {
 
-    private final RestClient userClient;
+    private final WebClient userClient;
 
-    public UserResolverImpl(RestClient.Builder restClientBuilder) {
-        this.userClient = restClientBuilder.baseUrl("http://localhost:8081/users").build();
+    public UserResolverImpl(WebClient.Builder restClientBuilder) {
+        this.userClient = restClientBuilder
+                .baseUrl("http://localhost:8081/users")
+                .build();
     }
 
-    public User createUser(User newUser){
+    public Mono<User> createUser(User newUser){
         return userClient.post()
-                .uri("")
-                .body(newUser)
+                .body(Mono.just(newUser), User.class)
                 .retrieve()
-                .body(User.class);
+                .bodyToMono(User.class);
     }
 
-    public List<User> getAllUsers(){
-        return userClient.get().retrieve().body(new ParameterizedTypeReference<List<User>>() {
-        });
+    public Flux<User> getAllUsers(){
+        return userClient.get()
+                .retrieve()
+                .bodyToFlux(User.class);
     }
 
-    public User updateUser(String documentNumber, User updateUser){
+    public Mono<User> updateUser(String documentNumber, UpdateUserInput updateUserInput){
+        final var updatedUser = getUserByDocumentNumber(documentNumber)
+                .map( existingUser ->
+                        new User(
+                                existingUser.documentIdentity(),
+                                Optional.ofNullable(updateUserInput.firstName()).orElse(existingUser.firstName()),
+                                Optional.ofNullable(updateUserInput.lastName()).orElse(existingUser.lastName()),
+                                Optional.ofNullable(updateUserInput.email()).orElse(existingUser.email()),
+                                Optional.ofNullable(updateUserInput.phoneNumber()).orElse(existingUser.phoneNumber()),
+                                Optional.ofNullable(updateUserInput.address()).orElse(existingUser.address())
+
+                    )
+                );
+
         return userClient.put()
                 .uri("/{documentNumber}", documentNumber)
-                .body(updateUser, new ParameterizedTypeReference<User>() {})
+                .body(updatedUser, User.class)
                 .retrieve()
-                .body(User.class);
+                .bodyToMono(User.class);
     }
 
-    public boolean deleteUser(String documentNumber){
-            userClient.delete()
-                    .uri("/{documentNumber}", documentNumber)
-                    .retrieve()
-                    .toBodilessEntity();
-                    return true;
-
+    public Mono<Boolean> deleteUser(String documentNumber) {
+        return userClient.delete()
+                .uri("/{documentNumber}", documentNumber)
+                .retrieve()
+                .onStatus(
+                        status -> status.is4xxClientError() || status.is5xxServerError(),
+                        clientResponse -> Mono.error(new HttpClientErrorException(clientResponse.statusCode()))
+                )
+                .bodyToMono(Void.class)
+                .then(Mono.just(true))
+                .onErrorReturn(false);
     }
 
-    public User getUserByDocumentNumber(String documentNumber) {
+    public Mono<User> getUserByDocumentNumber(String documentNumber) {
         return userClient.get()
                 .uri("/document/{documentNumber}", documentNumber)
                 .retrieve()
-                .body(User.class);
+                .bodyToMono(User.class);
     }
 
-    public List<User> getUserByFirstName(String firstName){
+    public Flux<User> getUserByFirstName(String firstName){
         return userClient.get()
                 .uri("/name/{firstName}", firstName)
                 .retrieve()
-                .body(new ParameterizedTypeReference<List<User>>() {});
+                .bodyToFlux(User.class);
     }
-
-
-
 
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -8,6 +8,7 @@ object Libraries {
     const val springbootRedis = "org.springframework.boot:spring-boot-starter-data-redis"
     const val springbootValidation = "org.springframework.boot:spring-boot-starter-validation"
     const val springbootWeb = "org.springframework.boot:spring-boot-starter-web"
+    const val springbootWebFlux = "org.springframework.boot:spring-boot-starter-webflux"
     const val mapStruct = "org.mapstruct:mapstruct:1.6.0"
     const val mapStructProcessor = "org.mapstruct:mapstruct-processor:1.6.0"
     const val vavr = "io.vavr:vavr:0.10.4"


### PR DESCRIPTION
Changes the MVC model of the Gateway to use WebFlux so it can handle multiple requests without losing too much performance.

Essentially, changes the `RestClient` to the `WebClient` so it returns `Mono` and `Flux` on each of the controllers. 

Also, it modifies the resolvers so you can now take advantage of the asynchronous nature of the streams. 